### PR TITLE
filenames: allow simple array or full hash containing target PDF filenames

### DIFF
--- a/lib/middleman-pdfkit/extension.rb
+++ b/lib/middleman-pdfkit/extension.rb
@@ -19,19 +19,44 @@ module Middleman
       end
 
       def after_build(builder)
-        @filenames.each do |pdfkit_filename|
-          html_filename = "build/#{pdfkit_filename}.html"
-          pdf_filename  = "build/#{pdfkit_filename}.pdf"
-          if File.exist?(html_filename)
-            generate_pdf(html_filename, pdf_filename)
-            puts "create", pdf_filename
-          else
-            puts "error", "#{pdf_filename} (HTML-File not found )", :red
+        # If filename is a classic Array, le's infer the output file name
+        if @filenames.is_a?(Array)
+
+          @filenames.each do |file|
+            build_pdf_for(file)
           end
+        
+        # If filename is a Hash, it provides the output file names
+        elsif @filenames.is_a?(Hash)
+
+          @filenames.each do |file, output|
+            build_pdf_for(file, output)
+          end
+
         end
       end
 
       private
+
+        def build_pdf_for input, output = nil
+          # Build two versions of input files and test them
+          file1 = "build/#{input}"
+          file2 = "build/#{input}.html"
+
+          # Default output filename if not specified
+          outfile ||= "build/#{output}"
+
+          # Test input flies presence
+          if File.exist?(file1)
+            puts "create", outfile
+            generate_pdf(file1, outfile)
+          elsif File.exist?(file2)
+            puts "create", outfile
+            generate_pdf(file2, outfile)
+          else
+            puts "error", "PDFKit: none of source HTML files [#{file1}, #{file2}] been found", :red
+          end
+        end
 
         def setup_filenames
           @filenames = options.filenames.empty? ? all_html_files : options.filenames

--- a/middleman-pdfkit.gemspec
+++ b/middleman-pdfkit.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "middleman-core",  ">= 3.0.0"
-  spec.add_dependency "pdfkit",          "~> 0.6.2"
+  spec.add_dependency "middleman-core",  ">= 4.2.1"
+  spec.add_dependency "pdfkit",          "~> 0.8.2"
   spec.add_dependency "wkhtmltopdf_binary_provider"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Patch to allow filenames hashes like : 
```
 activate :pdfkit do |p|
    p.filenames = {
      'pages-fr/index' => 'outpu-fr.pdf',
      'pages-en/index' => 'output-en.pdf',
     }
  end