### PR TITLE
filenames: allow simple array or full hash containing target PDF filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ configure :build do
   activate :relative_assets
   activate :pdfkit do |p|
     # p.filenames = ['test/test_page1', 'test/test_page2']
+    # p.filenames = {
+      'test/test_page1' => 'test/test_page1.pdf',
+      'test/test_page2' => 'test/test_page2.pdf',
+     }
     # p.disable_smart_shrinking = true
     # p.quiet = false
     # p.page_size = 'A5'

--- a/README.md
+++ b/README.md
@@ -19,7 +19,28 @@ Or install it yourself as:
 
 ## Usage
 
-* Activate pdfkit in your [config.rb](https://github.com/matt-hh/middleman-pdfkit-example/blob/master/config.rb#L5-L18)
+* Activate pdfkit in your [config.rb]
+
+```
+configure :build do
+  activate :relative_assets
+  activate :pdfkit do |p|
+    # p.filenames = ['test/test_page1', 'test/test_page2']
+    # p.disable_smart_shrinking = true
+    # p.quiet = false
+    # p.page_size = 'A5'
+    # p.margin_top = 10
+    # p.margin_right = 10
+    # p.margin_bottom = 10
+    # p.margin_left = 10
+    # p.encoding = 'UTF-8'
+  end
+end
+
+```
+
+
+
 * Execute `middleman build`
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ configure :build do
     # p.margin_right = 10
     # p.margin_bottom = 10
     # p.margin_left = 10
+    # p.print_media_type = true
     # p.encoding = 'UTF-8'
   end
 end

--- a/lib/middleman-pdfkit/extension.rb
+++ b/lib/middleman-pdfkit/extension.rb
@@ -14,14 +14,16 @@ module Middleman
       option :encoding,                 'UTF-8',  'Encoding'
 
       def initialize(klass, options_hash={}, &block)
+        @prefix = "build/"
+
         super
         setup_filenames
       end
 
       def after_build(builder)
         @filenames.each do |pdfkit_filename|
-          html_filename = "build/#{pdfkit_filename}.html"
-          pdf_filename  = "build/#{pdfkit_filename}.pdf"
+          html_filename = "#{@prefix}#{pdfkit_filename}.html"
+          pdf_filename  = "#{@prefix}#{pdfkit_filename}.pdf"
           if File.exist?(html_filename)
             generate_pdf(html_filename, pdf_filename)
             puts "create", pdf_filename
@@ -39,8 +41,8 @@ module Middleman
 
         def all_html_files
           # TODO: find a better way?!
-          Dir.glob(File.join('build', '**', '*.html')).map do |d|
-            File.join(File.dirname(d).sub('build', ''), File.basename(d, '.html'))[1..-1]
+          Dir.glob(File.join(@prefix, '**', '*.html')).map do |d|
+            File.join(File.dirname(d).sub(@prefix, ''), File.basename(d, '.html'))[1..-1]
           end
         end
 

--- a/lib/middleman-pdfkit/extension.rb
+++ b/lib/middleman-pdfkit/extension.rb
@@ -11,6 +11,7 @@ module Middleman
       option :margin_right,             '0',      'Margin right: 0'
       option :margin_bottom,            '0',      'Margin bottom: 0'
       option :margin_left,              '0',      'Margin left: 0'
+      option :print_media_type,         true,     'Print media type'
       option :encoding,                 'UTF-8',  'Encoding'
 
       def initialize(klass, options_hash={}, &block)
@@ -58,6 +59,7 @@ module Middleman
             encoding:                 options.encoding)
           file = kit.to_file(pdf_filename)
         end
+          print_media_type:         options.print_media_type,
 
     end
   end

--- a/lib/middleman-pdfkit/extension.rb
+++ b/lib/middleman-pdfkit/extension.rb
@@ -21,6 +21,16 @@ module Middleman
         setup_filenames
       end
 
+      def manipulate_resource_list(resources)
+        # Add my @filenames to Sitemap
+        @filenames.each do |input, output|
+          resources << Middleman::Sitemap::Extensions::EndpointResource.new(app.sitemap, output, "/")
+        end
+
+        # Return the new list
+        resources
+      end
+
       def after_build(builder)
         @filenames.each do |file, output|
           puts "after_build: [#{file}] > [#{output}]"
@@ -98,6 +108,7 @@ module Middleman
           print_media_type:         options.print_media_type,
           encoding:                 options.encoding)
         file = kit.to_file(pdf_filename)
+        # puts "pdfkit: #{kit.command}"
       end
 
     end

--- a/middleman-pdfkit.gemspec
+++ b/middleman-pdfkit.gemspec
@@ -6,8 +6,8 @@ require 'middleman-pdfkit/version'
 Gem::Specification.new do |spec|
   spec.name          = "middleman-pdfkit"
   spec.version       = Middleman::PDFKit::VERSION
-  spec.authors       = ["Matthias Döring"]
-  spec.email         = ["matt@foryourcontent.de"]
+  spec.authors       = ["Matthias Döring", "Naadir Jeewa", "Bruno Medici"]
+  spec.email         = ["matt@foryourcontent.de", "", "opensource@bmconseil.com"]
   spec.summary       = %q{PDFKit extension for middleman}
   spec.description   = %q{Generate PDFs from HTML/CSS with middleman}
   spec.homepage      = "https://github.com/matt-hh/middleman-pdfkit"
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "middleman-core",  ">= 3.0.0"
-  spec.add_dependency "pdfkit",          "~> 0.6.2"
+  spec.add_dependency "middleman-core",  ">= 4"
+  spec.add_dependency "pdfkit",          "~> 0.8"
   spec.add_dependency "wkhtmltopdf_binary_provider"
 
   spec.add_development_dependency "bundler", "~> 1.6"


### PR DESCRIPTION
Patch to allow filenames hashes like : 
```
 activate :pdfkit do |p|
    p.filenames = {
      'pages-fr/index' => 'outpu-fr.pdf',
      'pages-en/index' => 'output-en.pdf',
     }
  end